### PR TITLE
Fix of "error opening SPI device 2.5 Error: EINVAL ..."

### DIFF
--- a/rpi-ws2801/rpi-ws2801.js
+++ b/rpi-ws2801/rpi-ws2801.js
@@ -11,7 +11,7 @@ module.exports = function(RED) {
         if (node.port === "") {
             node.port = "/dev/spidev0.0";
         }
-        const numbers = node.port.match(/\d/g);
+        const numbers = node.port.match(/\d/g).map(Number);
         if(numbers.length !== 2) {
             node.error("ERROR: Cannot parse SPI port, did you specify the property correctly ? (Examples: /dev/spidev0.0  /dev/spidev0.1)");
         }

--- a/rpi-ws2801/rpi-ws2801.js
+++ b/rpi-ws2801/rpi-ws2801.js
@@ -11,11 +11,18 @@ module.exports = function(RED) {
         if (node.port === "") {
             node.port = "/dev/spidev0.0";
         }
+        const numbers = node.port.match(/\d/g);
+        if(numbers.length !== 2) {
+            node.error("ERROR: Cannot parse SPI port, did you specify the property correctly ? (Examples: /dev/spidev0.0  /dev/spidev0.1)");
+        }
+        node.spiBus = numbers[0];
+        node.spiDevice = numbers[1];
         
         node.gamma = parseFloat(config.gamma)
 
         try {
-            node.leds.connect(node.numLeds, node.port, node.gamma);
+            //connect: function(numLEDs, spiBus, spiDevice, gamma)
+            node.leds.connect(node.numLeds, node.spiBus, node.spiDevice, node.gamma);
         } catch (e) {
             node.error("ERROR: Cannot open SPI port, is it activated and are you on a Raspberry pi ?");
         }


### PR DESCRIPTION
As already explained in my issue, this fixes the above error by parsing the specified port from the node-red property "SPI port" and finds spiBus & spiDevice numbers in String like "/dev/spidev0.0".
If there are not exactly two numbers found, it calls node.error. Additional checks were not done.
Now this module works like a charm.
Greetings,
JimmyPesto